### PR TITLE
added example and removed exception from flow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-adk-arcade"
-version = "0.0.1"
+version = "0.0.2"
 description = "Arcade Integration for Google ADK"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Google ADK does not have proper async error handling. This PR:

* makes it so our authentication is returned as a plain message instead of raising an exception (so agents that rely on Arcade tools can retry and not bring the entire agent down)
* replaces the example on the readme file to an example that uses this library and authorizes BEFORE handling the user prompt